### PR TITLE
fix: rename signal.h to lunet_signal.h to fix Debian build

### DIFF
--- a/include/lunet_signal.h
+++ b/include/lunet_signal.h
@@ -1,5 +1,5 @@
-#ifndef SIGNAL_H
-#define SIGNAL_H
+#ifndef LUNET_SIGNAL_H
+#define LUNET_SIGNAL_H
 
 #include <lua.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 
 #include "co.h"
 #include "fs.h"
+#include "lunet_signal.h"
 #include "mysql.h"
 #include "rt.h"
 #include "socket.h"

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,9 +1,11 @@
-#include "signal.h"
+#include "lunet_signal.h"
 
 #include <lauxlib.h>
 #include <lua.h>
 #include <lualib.h>
+#include <signal.h>
 #include <stdlib.h>
+#include <string.h>
 #include <uv.h>
 
 #include "co.h"


### PR DESCRIPTION
## Summary

Fixes #1

Renames `include/signal.h` to `include/lunet_signal.h` to avoid shadowing the system's `<signal.h>` header, which causes build failures on Debian Trixie.

## Changes

- Rename `include/signal.h` to `include/lunet_signal.h`
- Update header guard to `LUNET_SIGNAL_H`
- Add `#include <signal.h>` in `src/signal.c` for SIGINT/SIGTERM/etc
- Add `#include <string.h>` in `src/signal.c` for strcmp
- Update `src/main.c` to include `lunet_signal.h`

## Testing

- Builds and passes tests on macOS
- Builds on Debian Trixie (GCC 14.2.0)