### PR TITLE
docs: 添加示例代码 / Add example code (#3)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -287,6 +287,13 @@ Lunet 专为高性能而设计：
 4. 添加测试（如适用）
 5. 提交拉取请求
 
+## 示例
+
+| 示例 | 描述 |
+|------|------|
+| [01_json.lua](examples/01_json.lua) | 纯 Lua JSON 编码器，结合 MySQL 集成 |
+| [02_routing.lua](examples/02_routing.lua) | HTTP 路由与 URL 参数提取（`:id`） |
+
 ## 许可证
 
 本项目采用 MIT 许可证 - 详情请参阅 [LICENSE](LICENSE) 文件。

--- a/README.md
+++ b/README.md
@@ -287,6 +287,13 @@ Contributions are welcome! Please feel free to submit issues and pull requests.
 4. Add tests if applicable
 5. Submit a pull request
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| [01_json.lua](examples/01_json.lua) | Pure Lua JSON encoding with MySQL integration |
+| [02_routing.lua](examples/02_routing.lua) | HTTP routing with URL parameter extraction (`:id`) |
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/examples/01_json.lua
+++ b/examples/01_json.lua
@@ -1,0 +1,135 @@
+-- Example: JSON Encoding with MySQL
+-- Demonstrates: Pure Lua JSON encoding, structured API responses
+--
+-- Setup:
+--   CREATE DATABASE IF NOT EXISTS hello;
+--   USE hello;
+--   CREATE TABLE messages (id INT AUTO_INCREMENT PRIMARY KEY, text VARCHAR(255));
+--   INSERT INTO messages (text) VALUES ('Hello, World!'), ('Welcome to lunet');
+
+local lunet = require("lunet")
+local socket = require("lunet.socket")
+local mysql = require("lunet.mysql")
+
+local db_config = {
+    host = os.getenv("DB_HOST") or "127.0.0.1",
+    port = tonumber(os.getenv("DB_PORT")) or 3306,
+    user = os.getenv("DB_USER") or "root",
+    password = os.getenv("DB_PASSWORD") or "root",
+    database = os.getenv("DB_NAME") or "hello",
+    charset = "utf8mb4",
+}
+
+local function escape_string(s)
+    local escapes = {
+        ['"'] = '\\"', ['\\'] = '\\\\', ['\n'] = '\\n',
+        ['\r'] = '\\r', ['\t'] = '\\t',
+    }
+    return s:gsub('["\\\n\r\t]', escapes)
+end
+
+local function json_encode(val)
+    local t = type(val)
+    if t == "nil" then
+        return "null"
+    elseif t == "boolean" then
+        return val and "true" or "false"
+    elseif t == "number" then
+        return tostring(val)
+    elseif t == "string" then
+        return '"' .. escape_string(val) .. '"'
+    elseif t == "table" then
+        local is_array = #val > 0 or next(val) == nil
+        local parts = {}
+        if is_array then
+            for i, v in ipairs(val) do
+                parts[i] = json_encode(v)
+            end
+            return "[" .. table.concat(parts, ",") .. "]"
+        else
+            for k, v in pairs(val) do
+                parts[#parts + 1] = '"' .. escape_string(tostring(k)) .. '":' .. json_encode(v)
+            end
+            return "{" .. table.concat(parts, ",") .. "}"
+        end
+    end
+    return "null"
+end
+
+local function json_response(status, data)
+    local body = json_encode(data)
+    return "HTTP/1.1 " .. status .. "\r\n" ..
+           "Content-Type: application/json; charset=utf-8\r\n" ..
+           "Content-Length: " .. #body .. "\r\n" ..
+           "Connection: close\r\n\r\n" .. body
+end
+
+local function parse_request_line(data)
+    local method, path = data:match("^(%S+)%s+(%S+)")
+    path = path and path:match("^([^?]+)") or path
+    return method, path
+end
+
+local request_count = 0
+
+lunet.spawn(function()
+    local port = tonumber(os.getenv("PORT")) or 8888
+    local listener, err = socket.listen("tcp", "0.0.0.0", port)
+    if not listener then
+        print("FATAL: Cannot listen: " .. (err or "unknown"))
+        return
+    end
+    print("JSON example running on http://0.0.0.0:" .. port)
+    print("Routes:")
+    print("  GET /messages -> list all messages as JSON")
+    print("  GET /         -> hello world")
+
+    while true do
+        local client = socket.accept(listener)
+        if client then
+            lunet.spawn(function()
+                request_count = request_count + 1
+
+                local data = socket.read(client)
+                if not data then
+                    socket.close(client)
+                    return
+                end
+
+                local method, path = parse_request_line(data)
+
+                if method == "GET" and path == "/" then
+                    socket.write(client, json_response("200 OK", {message = "Hello, World!"}))
+                    socket.close(client)
+                    return
+                end
+
+                if method == "GET" and path == "/messages" then
+                    local conn = mysql.open(db_config)
+                    if not conn then
+                        socket.write(client, json_response("500 Internal Server Error", {error = "database error"}))
+                        socket.close(client)
+                        return
+                    end
+
+                    local rows = mysql.query(conn, "SELECT id, text FROM messages ORDER BY id")
+                    mysql.close(conn)
+
+                    local messages = {}
+                    if rows then
+                        for _, row in ipairs(rows) do
+                            messages[#messages + 1] = {id = row.id, text = row.text}
+                        end
+                    end
+
+                    socket.write(client, json_response("200 OK", {messages = messages, count = #messages}))
+                    socket.close(client)
+                    return
+                end
+
+                socket.write(client, json_response("404 Not Found", {error = "not found"}))
+                socket.close(client)
+            end)
+        end
+    end
+end)

--- a/examples/02_routing.lua
+++ b/examples/02_routing.lua
@@ -1,0 +1,155 @@
+-- Example 2: Routing with Pattern Parameters
+-- Demonstrates: Route matching, URL parameter extraction
+-- Pattern syntax: /api/messages/:id
+--
+-- Setup:
+--   CREATE DATABASE IF NOT EXISTS hello;
+--   USE hello;
+--   CREATE TABLE messages (id INT AUTO_INCREMENT PRIMARY KEY, text VARCHAR(255));
+--   INSERT INTO messages (text) VALUES ('Hello, World!'), ('Welcome to lunet');
+
+local lunet = require("lunet")
+local socket = require("lunet.socket")
+local mysql = require("lunet.mysql")
+
+local db_config = {
+    host = os.getenv("DB_HOST") or "127.0.0.1",
+    port = tonumber(os.getenv("DB_PORT")) or 3306,
+    user = os.getenv("DB_USER") or "root",
+    password = os.getenv("DB_PASSWORD") or "root",
+    database = os.getenv("DB_NAME") or "hello",
+    charset = "utf8mb4",
+}
+
+local request_count = 0
+
+local function json_response(status, body)
+    return "HTTP/1.1 " .. status .. " OK\r\n" ..
+           "Content-Type: application/json\r\n" ..
+           "Content-Length: " .. #body .. "\r\n" ..
+           "Connection: close\r\n\r\n" .. body
+end
+
+local function handle_messages(conn, params)
+    local rows = mysql.query(conn, "SELECT id, text FROM messages ORDER BY id LIMIT 10")
+    local messages = {}
+    if rows then
+        for i, row in ipairs(rows) do
+            messages[i] = '{"id":' .. row.id .. ',"text":"' .. (row.text or "") .. '"}'
+        end
+    end
+    return '{"messages":[' .. table.concat(messages, ",") .. ']}'
+end
+
+local function handle_message_by_id(conn, params)
+    local id = tonumber(params.id) or 0
+    local rows = mysql.query(conn, "SELECT id, text FROM messages WHERE id = " .. id .. " LIMIT 1")
+    if rows and rows[1] then
+        return '{"message":{"id":' .. rows[1].id .. ',"text":"' .. (rows[1].text or "") .. '"}}'
+    end
+    return '{"error":"not found"}'
+end
+
+local function handle_status(conn, params)
+    return '{"status":"ok","version":"1.0"}'
+end
+
+local routes = {
+    {method = "GET", pattern = "/api/messages", handler = handle_messages},
+    {method = "GET", pattern = "/api/messages/:id", handler = handle_message_by_id},
+    {method = "GET", pattern = "/api/status", handler = handle_status},
+}
+
+local function match_route(method, path)
+    for _, route in ipairs(routes) do
+        if route.method == method then
+            local pattern_parts = {}
+            for part in route.pattern:gmatch("[^/]+") do
+                pattern_parts[#pattern_parts + 1] = part
+            end
+
+            local path_parts = {}
+            for part in path:gmatch("[^/]+") do
+                path_parts[#path_parts + 1] = part
+            end
+
+            if #pattern_parts == #path_parts then
+                local params = {}
+                local match = true
+                for i, pp in ipairs(pattern_parts) do
+                    if pp:sub(1, 1) == ":" then
+                        params[pp:sub(2)] = path_parts[i]
+                    elseif pp ~= path_parts[i] then
+                        match = false
+                        break
+                    end
+                end
+                if match then
+                    return route.handler, params
+                end
+            end
+        end
+    end
+    return nil, nil
+end
+
+local function parse_request_line(data)
+    local method, full_path = data:match("^(%S+)%s+(%S+)")
+    local path = full_path and full_path:match("^([^?]+)") or full_path
+    return method, path
+end
+
+local function handle_request(client, req_id)
+    local data, err = socket.read(client)
+    if not data then
+        socket.close(client)
+        return
+    end
+
+    local method, path = parse_request_line(data)
+    print("[" .. req_id .. "] " .. (method or "?") .. " " .. (path or "?"))
+
+    local handler, params = match_route(method, path)
+    if not handler then
+        socket.write(client, json_response(404, '{"error":"not found"}'))
+        socket.close(client)
+        return
+    end
+
+    local conn, db_err = mysql.open(db_config)
+    if not conn then
+        socket.write(client, json_response(500, '{"error":"database error"}'))
+        socket.close(client)
+        return
+    end
+
+    local body = handler(conn, params)
+    mysql.close(conn)
+
+    socket.write(client, json_response(200, body))
+    socket.close(client)
+end
+
+lunet.spawn(function()
+    local port = tonumber(os.getenv("PORT")) or 8888
+    local listener, err = socket.listen("tcp", "0.0.0.0", port)
+    if not listener then
+        print("FATAL: Cannot listen: " .. (err or "unknown"))
+        return
+    end
+    print("Example 2 (routing) running on http://0.0.0.0:" .. port)
+    print("Routes:")
+    print("  GET /api/messages")
+    print("  GET /api/messages/:id")
+    print("  GET /api/status")
+
+    while true do
+        local client = socket.accept(listener)
+        if client then
+            lunet.spawn(function()
+                request_count = request_count + 1
+                handle_request(client, request_count)
+            end)
+        end
+    end
+end)

--- a/src/mysql.c
+++ b/src/mysql.c
@@ -3,6 +3,7 @@
 #include <lauxlib.h>
 #include <lua.h>
 #include <mysql/mysql.h>
+#include <stdlib.h>
 
 #include "co.h"
 #include "uv.h"


### PR DESCRIPTION
## 中文

添加两个示例代码，展示 lunet 的核心功能：

1. **JSON 编码示例** (`examples/01_json.lua`) - 纯 Lua JSON 编码器，结合 MySQL 集成
2. **路由示例** (`examples/02_routing.lua`) - HTTP 路由与 URL 参数提取（如 `:id`）

同时在 README.md 中添加了示例表格。

修复：`src/mysql.c` 添加缺失的 `#include <stdlib.h>`

Closes #3

---

## English

Add two example scripts demonstrating core lunet features:

1. **JSON encoding example** (`examples/01_json.lua`) - Pure Lua JSON encoder with MySQL integration
2. **Routing example** (`examples/02_routing.lua`) - HTTP routing with URL parameter extraction (`:id`)

Also added an Examples table to README.md.

Fix: Added missing `#include <stdlib.h>` in `src/mysql.c`

Closes #3
